### PR TITLE
chore(infra): upgrade CodeQL Action from v3 to v4

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,11 +20,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: github/codeql-action/init@v3
+      - uses: github/codeql-action/init@v4
         with:
           languages: javascript-typescript
           queries: security-extended
 
-      - uses: github/codeql-action/autobuild@v3
+      - uses: github/codeql-action/autobuild@v4
 
-      - uses: github/codeql-action/analyze@v3
+      - uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
## Summary
- Upgrade `github/codeql-action` from v3 to v4 (init, autobuild, analyze) before v3 deprecation in December 2026

Fixes #15

## Files Changed
- `.github/workflows/codeql.yml` — updated all 3 action references from `@v3` to `@v4`

## Assumptions
- No configuration changes needed between v3 and v4 (the `languages` and `queries` inputs remain compatible)
- The `security-extended` query suite is still supported in v4

## Test plan
- [x] Local test suite passes (114/114 tests)
- [x] TypeScript typecheck passes
- [x] Production build succeeds
- [ ] CI CodeQL workflow runs successfully with v4

🤖 Generated with [Claude Code](https://claude.com/claude-code)