### PR TITLE
Hotfix 0.3.1: fix double-logging and show fetch root cause

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chapa-cli",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Merge GitHub EMU contributions into your Chapa developer impact badge",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

- **fix(emu)**: Stop double-logging errors when logger is provided — `log?.error() ?? console.error()` always fired both sides because `void` is `undefined`
- **fix(emu)**: Walk `error.cause` chain in fetch failures so corporate network users see the actual root cause (e.g. `fetch failed → ECONNREFUSED`) instead of just `fetch failed`
- **chore**: Bump version to 0.3.1

## Test plan
- [x] 173 tests passing (3 new regression tests)
- [x] TypeScript typecheck clean
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)