### PR TITLE
fix(build): bundle linkedom into dist, restore zero runtime deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,11 +45,9 @@
   "devDependencies": {
     "@types/node": "^25.5.0",
     "@vitest/coverage-v8": "^4.1.0",
+    "linkedom": "^0.18.12",
     "tsup": "^8.5.1",
     "typescript": "^5.7.3",
     "vitest": "^4.1.0"
-  },
-  "dependencies": {
-    "linkedom": "^0.18.12"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,10 +7,6 @@ settings:
 importers:
 
   .:
-    dependencies:
-      linkedom:
-        specifier: ^0.18.12
-        version: 0.18.12
     devDependencies:
       '@types/node':
         specifier: ^25.5.0
@@ -18,6 +14,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^4.1.0
         version: 4.1.0(vitest@4.1.0(@types/node@25.5.0)(vite@7.3.1(@types/node@25.5.0)))
+      linkedom:
+        specifier: ^0.18.12
+        version: 0.18.12
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(postcss@8.5.8)(typescript@5.9.3)

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
   outDir: "dist",
   clean: true,
   banner: { js: "#!/usr/bin/env node" },
+  noExternal: ["linkedom"],
   define: {
     __CLI_VERSION__: JSON.stringify(pkg.version),
   },


### PR DESCRIPTION
Closes #31

## Summary
- Added `noExternal: ["linkedom"]` to tsup config so linkedom is bundled into `dist/index.js`
- Moved `linkedom` from `dependencies` to `devDependencies`, restoring zero runtime dependencies
- Bundle size: 36KB → 478KB (linkedom inlined)

## Test plan
- [x] `pnpm run build` succeeds
- [x] `dist/index.js` has no external `from "linkedom"` import
- [x] All 226 tests pass
- [x] Typecheck clean