### PR TITLE
docs: update CHANGELOG for versions 0.2.9–0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-03-23
+
+### Added
+
+- `chapa insights` command for uploading Claude Code reports to Chapa
+- Auto-open browser on ENTER during `chapa login` (like `npm login`)
+
+### Changed
+
+- Drop Node 18 (EOL), require Node >=20, add Node 24 to CI matrix
+- Update dev dependencies (types, vitest, coverage)
+- Simplify insights file handling and remove DRY violations
+
+### Fixed
+
+- Login: use dependency injection for browser/readline in tests
+- Login: flush microtasks before advancing fake timers in tests
+- Login: resolve waitForEnter directly for Node 18 compatibility
+- Login: detach browser process and handle readline close
+
+### Documentation
+
+- Add EMU token setup guide with SAML SSO instructions and troubleshooting table
+- Document `--json` and `--verbose` flags
+- Add research and implementation plan for insights feature
+
 ## [0.2.8] - 2026-02-15
 
 ### Added
@@ -49,6 +75,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CI/CD pipeline with Node 18/20/22 matrix testing
 - Automated npm publishing on version bump
 
-[Unreleased]: https://github.com/juan294/chapa-cli/compare/v0.2.8...HEAD
+[Unreleased]: https://github.com/juan294/chapa-cli/compare/v0.3.1...HEAD
+[0.3.1]: https://github.com/juan294/chapa-cli/compare/v0.2.8...v0.3.1
 [0.2.8]: https://github.com/juan294/chapa-cli/compare/v0.2.7...v0.2.8
 [0.2.7]: https://github.com/juan294/chapa-cli/releases/tag/v0.2.7


### PR DESCRIPTION
Closes #32

## Summary
- Documented all changes from 0.2.8 through 0.3.1 in CHANGELOG.md
- Added entries for `insights` command, login browser auto-open, Node 18 EOL, dev deps
- Updated comparison links

## Test plan
- [x] CHANGELOG follows Keep a Changelog format
- [x] All versions documented
- [x] Comparison links updated