### PR TITLE
fix(cli): add error boundary, extract handlers, reduce process.exit

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -152,25 +152,24 @@ describe("index.ts command dispatch", () => {
 
   // ── --version ────────────────────────────────────────────────────────
 
-  it("outputs version and exits with code 0 for --version", async () => {
+  it("outputs version and returns cleanly for --version", async () => {
     mockParseArgs.mockReturnValue(defaultArgs({ version: true }));
 
     await runMain();
 
-    expect(mockExit).toHaveBeenCalledWith(0);
     const output = spyOutput(logSpy);
     // In dev/test mode, __CLI_VERSION__ is undefined so VERSION = "0.0.0-dev"
     expect(output).toContain("0.0.0-dev");
+    expect(mockExit).not.toHaveBeenCalled();
   });
 
   // ── --help ───────────────────────────────────────────────────────────
 
-  it("outputs help text and exits with code 0 for --help", async () => {
+  it("outputs help text and returns cleanly for --help", async () => {
     mockParseArgs.mockReturnValue(defaultArgs({ help: true }));
 
     await runMain();
 
-    expect(mockExit).toHaveBeenCalledWith(0);
     const output = spyOutput(logSpy);
     expect(output).toContain("chapa-cli");
     expect(output).toContain("Commands:");
@@ -179,6 +178,7 @@ describe("index.ts command dispatch", () => {
     expect(output).toContain("chapa merge");
     expect(output).toContain("--emu-handle");
     expect(output).toContain("--help");
+    expect(mockExit).not.toHaveBeenCalled();
   });
 
   it("help text includes --json and --verbose flags", async () => {
@@ -707,5 +707,91 @@ describe("index.ts command dispatch", () => {
       }),
     );
     expect(mockExit).not.toHaveBeenCalled();
+  });
+
+  // ── W12: top-level error boundary ─────────────────────────────────────
+
+  it("catches unexpected errors in main() and exits 1 via error boundary", async () => {
+    // Make parseArgs throw an unexpected error (simulating a bug)
+    mockParseArgs.mockImplementation(() => {
+      throw new Error("Unexpected kaboom");
+    });
+
+    await runMain();
+
+    expect(mockExit).toHaveBeenCalledWith(1);
+    const output = spyOutput(errorSpy);
+    expect(output).toContain("Unexpected kaboom");
+  });
+
+  it("error boundary handles non-Error thrown values", async () => {
+    // Throw a string instead of an Error
+    mockParseArgs.mockImplementation(() => {
+      throw "string error value";
+    });
+
+    await runMain();
+
+    expect(mockExit).toHaveBeenCalledWith(1);
+    const output = spyOutput(errorSpy);
+    expect(output).toContain("string error value");
+  });
+
+  // ── W9: handler errors surface correctly ──────────────────────────────
+
+  it("exits 1 when login() throws an unexpected error", async () => {
+    mockParseArgs.mockReturnValue(defaultArgs({ command: "login" }));
+    mockLogin.mockRejectedValue(new Error("Network timeout"));
+
+    await runMain();
+
+    expect(mockExit).toHaveBeenCalledWith(1);
+    const output = spyOutput(errorSpy);
+    expect(output).toContain("Network timeout");
+  });
+
+  it("exits 1 when fetchEmuStats throws an unexpected error", async () => {
+    mockParseArgs.mockReturnValue(
+      defaultArgs({
+        command: "merge",
+        emuHandle: "corp_user",
+        handle: "juan294",
+        token: "auth-tok",
+      }),
+    );
+    mockLoadConfig.mockReturnValue(null);
+    mockResolveToken.mockReturnValue("emu-tok");
+    mockFetchEmuStats.mockRejectedValue(new Error("GraphQL schema mismatch"));
+
+    await runMain();
+
+    expect(mockExit).toHaveBeenCalledWith(1);
+    const output = spyOutput(errorSpy);
+    expect(output).toContain("GraphQL schema mismatch");
+  });
+
+  it("exits 1 when uploadSupplementalStats throws an unexpected error", async () => {
+    mockParseArgs.mockReturnValue(
+      defaultArgs({
+        command: "merge",
+        emuHandle: "corp_user",
+        handle: "juan294",
+        token: "auth-tok",
+      }),
+    );
+    mockLoadConfig.mockReturnValue(null);
+    mockResolveToken.mockReturnValue("emu-tok");
+    mockFetchEmuStats.mockResolvedValue({
+      commitsTotal: 42,
+      prsMergedCount: 5,
+      reviewsSubmittedCount: 3,
+    });
+    mockUploadSupplementalStats.mockRejectedValue(new Error("Connection reset"));
+
+    await runMain();
+
+    expect(mockExit).toHaveBeenCalledWith(1);
+    const output = spyOutput(errorSpy);
+    expect(output).toContain("Connection reset");
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { parseArgs } from "./cli.js";
+import type { CliArgs } from "./cli.js";
 import { resolveToken } from "./auth.js";
 import { fetchEmuStats } from "./fetch-emu.js";
 import { uploadSupplementalStats } from "./upload.js";
@@ -35,56 +36,30 @@ Options:
   --help, -h              Show this help message
 `;
 
-async function main(): Promise<void> {
-  const args = parseArgs(process.argv.slice(2));
-
-  if (args.version) {
-    console.log(VERSION);
-    process.exit(0);
+/** Sentinel error for known CLI error exits (validation failures, expected errors). */
+class CliError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "CliError";
   }
+}
 
-  if (args.help) {
-    console.log(HELP_TEXT);
-    process.exit(0);
+// ── Command Handlers ──────────────────────────────────────────────────────
+
+async function handleLogin(args: CliArgs): Promise<void> {
+  await login(args.server, { verbose: args.verbose, insecure: args.insecure });
+}
+
+function handleLogout(): void {
+  const removed = deleteConfig();
+  if (removed) {
+    console.log("Logged out. Credentials removed from ~/.chapa/credentials.json");
+  } else {
+    console.log("Not logged in (no credentials found).");
   }
+}
 
-  // --json and --verbose are mutually exclusive
-  if (args.json && args.verbose) {
-    console.error("Error: --json and --verbose cannot be used together.");
-    process.exit(1);
-  }
-
-  // Global TLS bypass for corporate networks — applies to all commands
-  if (args.insecure) {
-    process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
-    console.warn("\n⚠ TLS certificate verification disabled (--insecure).");
-    console.warn("  Use only on corporate networks with TLS interception.\n");
-  }
-
-  // ── login ────────────────────────────────────────────────────────────
-  if (args.command === "login") {
-    await login(args.server, { verbose: args.verbose, insecure: args.insecure });
-    return;
-  }
-
-  // ── logout ───────────────────────────────────────────────────────────
-  if (args.command === "logout") {
-    const removed = deleteConfig();
-    if (removed) {
-      console.log("Logged out. Credentials removed from ~/.chapa/credentials.json");
-    } else {
-      console.log("Not logged in (no credentials found).");
-    }
-    return;
-  }
-
-  // ── merge ────────────────────────────────────────────────────────────
-  if (args.command !== "merge") {
-    console.error("Usage: chapa <login | logout | merge> [options]");
-    console.error("\nRun 'chapa --help' for more information.");
-    process.exit(1);
-  }
-
+async function handleMerge(args: CliArgs): Promise<void> {
   const log = createLogger({ verbose: args.verbose, json: args.json });
   log.time("total");
 
@@ -96,25 +71,25 @@ async function main(): Promise<void> {
 
   if (!emuHandle) {
     log.error("Error: --emu-handle is required.");
-    process.exit(1);
+    throw new CliError("--emu-handle is required");
   }
 
   if (!handle) {
     log.error("Error: No personal handle found. Run 'chapa login' first, or pass --handle.");
-    process.exit(1);
+    throw new CliError("No personal handle found");
   }
 
   // Resolve tokens — CLI config token takes priority over GITHUB_TOKEN for auth
   const emuToken = resolveToken(args.emuToken, "GITHUB_EMU_TOKEN");
   if (!emuToken) {
     log.error("Error: EMU token required. Use --emu-token or set GITHUB_EMU_TOKEN.");
-    process.exit(1);
+    throw new CliError("EMU token required");
   }
 
   const authToken = args.token ?? config?.token;
   if (!authToken) {
     log.error("Error: Not authenticated. Run 'chapa login' first, or pass --token.");
-    process.exit(1);
+    throw new CliError("Not authenticated");
   }
 
   // Fetch EMU stats
@@ -125,7 +100,7 @@ async function main(): Promise<void> {
 
   if (!emuStats) {
     log.error("Error: Failed to fetch EMU stats. Check your EMU token and handle.");
-    process.exit(1);
+    throw new CliError("Failed to fetch EMU stats");
   }
 
   log.info(formatStatsSummary(emuStats));
@@ -177,7 +152,7 @@ async function main(): Promise<void> {
       cliVersion: VERSION,
     });
 
-    process.exit(1);
+    throw new CliError(result.error ?? "Upload failed");
   }
 
   // ── Success output ───────────────────────────────────────────────────
@@ -225,9 +200,66 @@ async function main(): Promise<void> {
   });
 }
 
+// ── Main Dispatcher ───────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+
+  if (args.version) {
+    console.log(VERSION);
+    return;
+  }
+
+  if (args.help) {
+    console.log(HELP_TEXT);
+    return;
+  }
+
+  // --json and --verbose are mutually exclusive
+  if (args.json && args.verbose) {
+    console.error("Error: --json and --verbose cannot be used together.");
+    throw new CliError("--json and --verbose cannot be used together");
+  }
+
+  // Global TLS bypass for corporate networks — applies to all commands
+  if (args.insecure) {
+    process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+    console.warn("\n⚠ TLS certificate verification disabled (--insecure).");
+    console.warn("  Use only on corporate networks with TLS interception.\n");
+  }
+
+  if (args.command === "login") {
+    await handleLogin(args);
+    return;
+  }
+
+  if (args.command === "logout") {
+    handleLogout();
+    return;
+  }
+
+  if (args.command === "merge") {
+    await handleMerge(args);
+    return;
+  }
+
+  // Unknown or missing command
+  console.error("Usage: chapa <login | logout | merge> [options]");
+  console.error("\nRun 'chapa --help' for more information.");
+  throw new CliError("Unknown command");
+}
+
 /** Round to 1 decimal place. */
 function round(n: number): number {
   return Math.round(n * 10) / 10;
 }
 
-main();
+// ── Error boundary ────────────────────────────────────────────────────────
+main().catch((err: unknown) => {
+  // CliError messages are already printed by the handlers above;
+  // only print for unexpected errors.
+  if (!(err instanceof CliError)) {
+    console.error(err instanceof Error ? err.message : String(err));
+  }
+  process.exit(1);
+});


### PR DESCRIPTION
Closes #34

## Summary
- Added top-level `.catch()` on `main()` for user-friendly error boundary
- Extracted `handleLogin()`, `handleLogout()`, `handleMerge()` from monolithic `main()`
- Reduced `process.exit()` from 10 calls to 1 (error boundary only)
- Introduced `CliError` sentinel class for known validation errors
- Added 5 new tests for error boundary behavior

## Test plan
- [x] Error boundary catches unexpected errors
- [x] Error boundary handles non-Error thrown values
- [x] Extracted handlers maintain existing behavior
- [x] All 178 tests pass
- [x] Typecheck clean