### PR TITLE
fix: extract shared utilities, dedup, harden login, add test coverage

### DIFF
--- a/src/fetch-emu.test.ts
+++ b/src/fetch-emu.test.ts
@@ -363,6 +363,26 @@ describe("fetchEmuStats", () => {
     errorSpy.mockRestore();
   });
 
+  it("falls back gracefully when res.text() rejects on HTTP error", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: async () => { throw new Error("body stream exhausted"); },
+    });
+
+    const result = await fetchEmuStats("corp_user", "ghp_token");
+    expect(result).toBeNull();
+
+    // Should still log something meaningful despite text() failing
+    const logged = errorSpy.mock.calls[0]![0] as string;
+    expect(logged).toContain("500");
+    expect(logged).toContain("(unreadable)");
+
+    errorSpy.mockRestore();
+  });
+
   it("filters out null PR nodes", async () => {
     mockFetch.mockResolvedValue({
       ok: true,

--- a/src/fetch-emu.ts
+++ b/src/fetch-emu.ts
@@ -1,5 +1,5 @@
 import type { StatsData, RawContributionData } from "./shared.js";
-import { CONTRIBUTION_QUERY, buildStatsFromRaw, SCORING_WINDOW_DAYS } from "./shared.js";
+import { CONTRIBUTION_QUERY, buildStatsFromRaw, SCORING_WINDOW_DAYS, extractErrorDetail } from "./shared.js";
 import type { Logger } from "./logger.js";
 
 // ---------------------------------------------------------------------------
@@ -73,24 +73,11 @@ function truncate(s: string, max: number): string {
   return s.length > max ? s.slice(0, max) + "..." : s;
 }
 
-/** Extract a useful error message, walking error.cause chain for root cause. */
-function extractErrorDetail(err: Error): string {
-  const parts = [err.message];
-  let current: unknown = err.cause;
-  while (current instanceof Error) {
-    if (current.message && current.message !== err.message) {
-      parts.push(current.message);
-    }
-    current = current.cause;
-  }
-  return parts.join(" → ");
-}
-
 // ---------------------------------------------------------------------------
 // Fetch EMU stats via GraphQL (requires EMU token with auth)
 // ---------------------------------------------------------------------------
 
-export interface FetchEmuOptions {
+interface FetchEmuOptions {
   logger?: Logger;
 }
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,4 +1,4 @@
-export interface LoggerOptions {
+interface LoggerOptions {
   verbose: boolean;
   json: boolean;
 }

--- a/src/login.test.ts
+++ b/src/login.test.ts
@@ -467,4 +467,59 @@ describe("login", () => {
 
     mockExit.mockRestore();
   });
+
+  it("times out after MAX_POLL_ATTEMPTS with persistent pending status", { timeout: 30000 }, async () => {
+    vi.useRealTimers(); // Switch to real timers — fake timers struggle with 150 iterations
+
+    const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+      throw new Error("process.exit");
+    }) as never);
+    const errorSpy = vi.spyOn(console, "error");
+
+    // Override the sleep by mocking setTimeout to resolve immediately
+    // so we don't actually wait 300 seconds
+    const origSetTimeout = globalThis.setTimeout;
+    vi.stubGlobal("setTimeout", ((fn: () => void) => origSetTimeout(fn, 0)) as typeof setTimeout);
+
+    // Always return pending
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ status: "pending" }), { status: 200 }),
+    ));
+
+    await expect(login("https://example.com")).rejects.toThrow("process.exit");
+    expect(mockExit).toHaveBeenCalledWith(1);
+
+    const allErrors = errorSpy.mock.calls.map(c => c.join(" ")).join("\n");
+    expect(allErrors).toContain("Timed out");
+
+    vi.stubGlobal("setTimeout", origSetTimeout);
+    mockExit.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it("prints a progress dot after every poll, not every 5 polls", async () => {
+    const writeSpy = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+    let callCount = 0;
+    vi.mocked(fetch).mockImplementation(async () => {
+      callCount++;
+      if (callCount < 4) {
+        return new Response(JSON.stringify({ status: "pending" }), { status: 200 });
+      }
+      return new Response(
+        JSON.stringify({ status: "approved", token: "t", handle: "h" }),
+        { status: 200 },
+      );
+    });
+
+    const p = login("https://example.com");
+    for (let i = 0; i < 4; i++) await advancePoll();
+    await p;
+
+    // With 3 pending polls, we should get dots starting from poll index 1
+    // (poll 0 is skipped as the initial poll, dots start at i > 0)
+    const dots = writeSpy.mock.calls.filter(c => c[0] === ".").length;
+    // Previously only every 5 polls got a dot; now every poll after the first
+    expect(dots).toBeGreaterThanOrEqual(2);
+    writeSpy.mockRestore();
+  });
 });

--- a/src/login.ts
+++ b/src/login.ts
@@ -9,6 +9,7 @@
 
 import { randomUUID } from "node:crypto";
 import { saveConfig } from "./config.js";
+import { stripTrailingSlashes, getRootErrorMessage, getFullErrorChain } from "./shared.js";
 
 export const POLL_INTERVAL_MS = 2000;
 const MAX_POLL_ATTEMPTS = 150; // 5 minutes at 2s intervals
@@ -46,40 +47,10 @@ function isTlsError(message: string): boolean {
   return TLS_ERROR_PATTERNS.some((p) => message.includes(p));
 }
 
-/**
- * Walk the error `.cause` chain and return the deepest message.
- * Node.js `fetch()` wraps real errors: Error("fetch failed", { cause: Error("UNABLE_TO_VERIFY_LEAF_SIGNATURE") })
- */
-function getRootErrorMessage(err: unknown): string {
-  let current = err;
-  let message = "";
-  while (current instanceof Error) {
-    message = current.message;
-    current = (current as Error & { cause?: unknown }).cause;
-  }
-  return message;
-}
-
-/**
- * Collect all messages and error codes from the cause chain (for TLS pattern matching).
- * Includes both .message and .code from each error in the chain.
- */
-function getFullErrorChain(err: unknown): string {
-  const parts: string[] = [];
-  let current = err;
-  while (current instanceof Error) {
-    parts.push(current.message);
-    const code = (current as Error & { code?: string }).code;
-    if (code) parts.push(code);
-    current = (current as Error & { cause?: unknown }).cause;
-  }
-  return parts.join(" | ");
-}
-
 export async function login(serverUrl: string, opts: LoginOptions = {}): Promise<void> {
   const { verbose = false, insecure = false } = opts;
 
-  const baseUrl = serverUrl.replace(/\/+$/, "");
+  const baseUrl = stripTrailingSlashes(serverUrl);
   const sessionId = randomUUID();
   const authorizeUrl = `${baseUrl}/cli/authorize?session=${sessionId}`;
 
@@ -93,8 +64,8 @@ export async function login(serverUrl: string, opts: LoginOptions = {}): Promise
   for (let i = 0; i < MAX_POLL_ATTEMPTS; i++) {
     await sleep(POLL_INTERVAL_MS);
 
-    // Progress feedback every 5 polls
-    if (i > 0 && i % 5 === 0) {
+    // Progress feedback every poll
+    if (i > 0) {
       process.stdout.write(".");
     }
 

--- a/src/shared.test.ts
+++ b/src/shared.test.ts
@@ -3,6 +3,10 @@ import {
   computePrWeight,
   buildStatsFromRaw,
   formatStatsSummary,
+  stripTrailingSlashes,
+  getRootErrorMessage,
+  getFullErrorChain,
+  extractErrorDetail,
   CONTRIBUTION_QUERY,
   SCORING_WINDOW_DAYS,
   PR_WEIGHT_AGG_CAP,
@@ -768,5 +772,119 @@ describe("formatStatsSummary", () => {
     const summary = formatStatsSummary(makeStats());
     const lines = summary.split("\n").filter((l) => l.trim().length > 0);
     expect(lines.length).toBeGreaterThanOrEqual(8);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// stripTrailingSlashes
+// ---------------------------------------------------------------------------
+
+describe("stripTrailingSlashes", () => {
+  it("removes a single trailing slash", () => {
+    expect(stripTrailingSlashes("https://example.com/")).toBe("https://example.com");
+  });
+
+  it("removes multiple trailing slashes", () => {
+    expect(stripTrailingSlashes("https://example.com///")).toBe("https://example.com");
+  });
+
+  it("returns the string unchanged when there is no trailing slash", () => {
+    expect(stripTrailingSlashes("https://example.com")).toBe("https://example.com");
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(stripTrailingSlashes("")).toBe("");
+  });
+
+  it("does not remove internal slashes", () => {
+    expect(stripTrailingSlashes("https://example.com/api/v1/")).toBe("https://example.com/api/v1");
+  });
+
+  it("handles a string that is just slashes", () => {
+    expect(stripTrailingSlashes("///")).toBe("");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getRootErrorMessage
+// ---------------------------------------------------------------------------
+
+describe("getRootErrorMessage", () => {
+  it("returns the message from a simple error", () => {
+    expect(getRootErrorMessage(new Error("simple error"))).toBe("simple error");
+  });
+
+  it("returns the deepest cause message from a nested error chain", () => {
+    const root = new Error("root cause");
+    const mid = new Error("middle", { cause: root });
+    const top = new Error("top level", { cause: mid });
+    expect(getRootErrorMessage(top)).toBe("root cause");
+  });
+
+  it("returns empty string for non-Error input", () => {
+    expect(getRootErrorMessage("not an error")).toBe("");
+  });
+
+  it("handles a single-level error (no cause)", () => {
+    expect(getRootErrorMessage(new Error("only one"))).toBe("only one");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getFullErrorChain
+// ---------------------------------------------------------------------------
+
+describe("getFullErrorChain", () => {
+  it("returns message from a single error", () => {
+    expect(getFullErrorChain(new Error("single"))).toContain("single");
+  });
+
+  it("includes all messages from the cause chain", () => {
+    const root = new Error("root");
+    const mid = new Error("mid", { cause: root });
+    const top = new Error("top", { cause: mid });
+    const result = getFullErrorChain(top);
+    expect(result).toContain("top");
+    expect(result).toContain("mid");
+    expect(result).toContain("root");
+  });
+
+  it("includes error codes when present", () => {
+    const err = Object.assign(new Error("cert failed"), { code: "SELF_SIGNED_CERT_IN_CHAIN" });
+    const result = getFullErrorChain(err);
+    expect(result).toContain("cert failed");
+    expect(result).toContain("SELF_SIGNED_CERT_IN_CHAIN");
+  });
+
+  it("returns empty string for non-Error input", () => {
+    expect(getFullErrorChain("not an error")).toBe("");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractErrorDetail
+// ---------------------------------------------------------------------------
+
+describe("extractErrorDetail", () => {
+  it("returns just the message for a simple error", () => {
+    expect(extractErrorDetail(new Error("simple"))).toBe("simple");
+  });
+
+  it("chains messages with arrow separator", () => {
+    const root = new Error("ECONNREFUSED 127.0.0.1:443");
+    const top = new Error("fetch failed", { cause: root });
+    const result = extractErrorDetail(top);
+    expect(result).toContain("fetch failed");
+    expect(result).toContain("ECONNREFUSED");
+    expect(result).toContain("→");
+  });
+
+  it("skips duplicate messages in the chain", () => {
+    const root = new Error("same message");
+    const top = new Error("same message", { cause: root });
+    const result = extractErrorDetail(top);
+    // Should not contain the message twice
+    const count = result.split("same message").length - 1;
+    expect(count).toBe(1);
   });
 });

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -168,6 +168,62 @@ query($login: String!, $since: DateTime!, $until: DateTime!, $historySince: GitT
 `;
 
 // ---------------------------------------------------------------------------
+// URL helpers
+// ---------------------------------------------------------------------------
+
+/** Remove trailing slashes from a URL string. */
+export function stripTrailingSlashes(url: string): string {
+  return url.replace(/\/+$/, "");
+}
+
+// ---------------------------------------------------------------------------
+// Error chain utilities
+// ---------------------------------------------------------------------------
+
+/**
+ * Walk the error `.cause` chain and return the deepest message.
+ * Node.js `fetch()` wraps real errors: Error("fetch failed", { cause: Error("UNABLE_TO_VERIFY_LEAF_SIGNATURE") })
+ */
+export function getRootErrorMessage(err: unknown): string {
+  let current = err;
+  let message = "";
+  while (current instanceof Error) {
+    message = current.message;
+    current = (current as Error & { cause?: unknown }).cause;
+  }
+  return message;
+}
+
+/**
+ * Collect all messages and error codes from the cause chain (for TLS pattern matching).
+ * Includes both .message and .code from each error in the chain.
+ */
+export function getFullErrorChain(err: unknown): string {
+  const parts: string[] = [];
+  let current = err;
+  while (current instanceof Error) {
+    parts.push(current.message);
+    const code = (current as Error & { code?: string }).code;
+    if (code) parts.push(code);
+    current = (current as Error & { cause?: unknown }).cause;
+  }
+  return parts.join(" | ");
+}
+
+/** Extract a useful error message, walking error.cause chain for root cause. */
+export function extractErrorDetail(err: Error): string {
+  const parts = [err.message];
+  let current: unknown = err.cause;
+  while (current instanceof Error) {
+    if (current.message && current.message !== err.message) {
+      parts.push(current.message);
+    }
+    current = current.cause;
+  }
+  return parts.join(" → ");
+}
+
+// ---------------------------------------------------------------------------
 // Scoring helpers
 // ---------------------------------------------------------------------------
 

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -1,3 +1,5 @@
+import { stripTrailingSlashes } from "./shared.js";
+
 export interface TelemetryPayload {
   operationId: string;
   targetHandle: string;
@@ -33,7 +35,7 @@ export async function sendTelemetry(
   serverUrl: string,
   payload: TelemetryPayload,
 ): Promise<void> {
-  const baseUrl = serverUrl.replace(/\/+$/, "");
+  const baseUrl = stripTrailingSlashes(serverUrl);
   const url = `${baseUrl}/api/telemetry`;
 
   try {

--- a/src/upload.test.ts
+++ b/src/upload.test.ts
@@ -121,6 +121,47 @@ describe("uploadSupplementalStats", () => {
     expect(result.error).toContain("Connection refused");
   });
 
+  it("falls back when res.json() rejects on error response", async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: async () => { throw new Error("invalid json"); },
+    });
+
+    const result = await uploadSupplementalStats({
+      targetHandle: "juan294",
+      sourceHandle: "corp_user",
+      stats: makeStats(),
+      token: "gho_personal",
+      serverUrl: "https://chapa.thecreativetoken.com",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("500");
+    // Fallback should produce "Unknown error" since json() failed
+    expect(result.error).toContain("Unknown error");
+  });
+
+  it("falls back when res.json() rejects on success response", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => { throw new Error("invalid json"); },
+    });
+
+    const result = await uploadSupplementalStats({
+      targetHandle: "juan294",
+      sourceHandle: "corp_user",
+      stats: makeStats(),
+      token: "gho_personal",
+      serverUrl: "https://chapa.thecreativetoken.com",
+    });
+
+    // Should still succeed — the fallback {} is used for serverResponse
+    expect(result.success).toBe(true);
+    expect(result.serverResponse).toEqual({});
+  });
+
   it("strips trailing slash from server URL", async () => {
     mockFetch.mockResolvedValue({
       ok: true,

--- a/src/upload.ts
+++ b/src/upload.ts
@@ -1,7 +1,8 @@
 import type { StatsData } from "./shared.js";
+import { stripTrailingSlashes } from "./shared.js";
 import type { Logger } from "./logger.js";
 
-export interface UploadOptions {
+interface UploadOptions {
   targetHandle: string;
   sourceHandle: string;
   stats: StatsData;
@@ -10,7 +11,7 @@ export interface UploadOptions {
   logger?: Logger;
 }
 
-export interface UploadResult {
+interface UploadResult {
   success: boolean;
   error?: string;
   serverResponse?: unknown;
@@ -19,7 +20,7 @@ export interface UploadResult {
 export async function uploadSupplementalStats(
   opts: UploadOptions,
 ): Promise<UploadResult> {
-  const baseUrl = opts.serverUrl.replace(/\/+$/, "");
+  const baseUrl = stripTrailingSlashes(opts.serverUrl);
   const url = `${baseUrl}/api/supplemental`;
   const log = opts.logger;
 


### PR DESCRIPTION
Closes #35

## Summary
- Extracted `stripTrailingSlashes()` to shared.ts, replacing duplication in 3 files
- Consolidated error chain utilities (`getRootErrorMessage`, `getFullErrorChain`, `extractErrorDetail`) into shared.ts
- Made unused type exports module-private (UploadOptions, UploadResult, FetchEmuOptions, LoggerOptions)
- Added 22 new tests: shared utilities, MAX_POLL timeout, response body parse fallbacks
- Improved login polling feedback (dots every 2s instead of every 10s)

## Test plan
- [x] 6 tests for `stripTrailingSlashes()` edge cases
- [x] 11 tests for error chain utilities
- [x] MAX_POLL_ATTEMPTS timeout test
- [x] Response body parse fallback tests (fetch-emu, upload)
- [x] Login polling dot frequency test
- [x] All 195 tests pass
- [x] Typecheck clean