### PR TITLE
chore(infra): add automated npm publish workflow on release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,49 @@
+# Publish to npm when a GitHub Release is published.
+#
+# npm 2FA considerations:
+# - If the npm account uses "Require 2FA for authorization and publishing"
+#   (the strictest level), automated publishing will FAIL because npm
+#   demands an OTP for every publish, which CI cannot provide.
+# - If the npm account uses "Require 2FA for authorization only" (the
+#   default when 2FA is enabled), an automation or granular access token
+#   stored in NPM_TOKEN can publish without an OTP.
+# - Recommendation: use a granular access token scoped to this package
+#   with read-write permissions. The token-expiry-reminder workflow
+#   tracks rotation for this token.
+
+name: Publish to npm
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: pnpm
+          registry-url: https://registry.npmjs.org
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm run typecheck
+
+      - run: pnpm test
+
+      - run: pnpm run build
+
+      - run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Closes #36

## Summary
- Added `.github/workflows/publish.yml` triggered on GitHub release publication
- Runs full verification pipeline (install, typecheck, test, build) before publishing
- Uses `npm publish --provenance --access public` with `NPM_TOKEN` secret
- Documents npm 2FA scenarios (automation token vs strict 2FA)

## Test plan
- [x] YAML syntax is valid
- [x] Workflow matches project conventions (pnpm, Node 22)
- [x] NPM_TOKEN secret already exists (referenced in token-expiry-reminder.yml)