### PR TITLE
chore: ignore vite in Dependabot (managed via pnpm overrides)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,9 @@ updates:
         update-types:
           - minor
           - patch
+    ignore:
+      - dependency-name: vite
+        reason: managed via pnpm overrides in package.json
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
## Summary

- Adds `vite` to Dependabot's ignore list for the npm ecosystem
- vite is a transitive dep (pulled in by vitest) pinned to the patched version `7.3.2` via pnpm overrides in `package.json`
- Dependabot's security updater was repeatedly failing because it cannot update transitive dependencies directly — this stops the noise

## Test plan

- [x] No code changes — config only
- CI should pass (no lockfile changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)