### PR TITLE
fix(ci): remove explicit pnpm version from publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,8 +35,6 @@ jobs:
           fi
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
## Summary

- Removes the hardcoded `version: 10` from `pnpm/action-setup@v4` in `publish.yml`
- Reads pnpm version from `packageManager` field in `package.json` instead (same fix already applied to CI workflow)

## Why

The `v0.4.1` publish workflow failed immediately with:
> Multiple versions of pnpm specified: version 10 in the GitHub Action config / pnpm@10.33.0 in package.json

## Test plan
- [x] Blocked publish run 24623413083 diagnosed and root cause confirmed
- [x] One-line fix matches the pattern from `fix(ci)` commit already on develop

🤖 Generated with [Claude Code](https://claude.com/claude-code)