### PR TITLE
fix: senior-dev validation fixes (6 items) #87

### DIFF
--- a/src/background.test.ts
+++ b/src/background.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { spawn } from "node:child_process";
+import { spawnDetachedPost } from "./background.js";
+
+vi.mock("node:child_process", () => ({
+  spawn: vi.fn(() => ({ unref: vi.fn() })),
+}));
+
+const mockSpawn = vi.mocked(spawn);
+
+function getChildEnv(): NodeJS.ProcessEnv | undefined {
+  const call = mockSpawn.mock.calls[0] as unknown[] | undefined;
+  const opts = call?.[2] as { env?: NodeJS.ProcessEnv } | undefined;
+  return opts?.env;
+}
+
+function getMockUnref(): ReturnType<typeof vi.fn> {
+  const result = mockSpawn.mock.results[0]?.value as { unref: ReturnType<typeof vi.fn> } | undefined;
+  return result?.unref ?? vi.fn();
+}
+
+describe("spawnDetachedPost env isolation", () => {
+  beforeEach(() => {
+    mockSpawn.mockClear();
+    mockSpawn.mockReturnValue({ unref: vi.fn() } as unknown as ReturnType<typeof spawn>);
+  });
+
+  it("does not leak GITHUB_EMU_TOKEN to the child", () => {
+    process.env.GITHUB_EMU_TOKEN = "super-secret";
+    try {
+      spawnDetachedPost({ url: "https://x.test", timeoutMs: 1000 });
+      const env = getChildEnv();
+      expect(env).toBeDefined();
+      expect(env!.GITHUB_EMU_TOKEN).toBeUndefined();
+    } finally {
+      delete process.env.GITHUB_EMU_TOKEN;
+    }
+  });
+
+  it("does not leak arbitrary shell vars to the child", () => {
+    process.env.AWS_SECRET_ACCESS_KEY = "aws-secret";
+    process.env.NPM_TOKEN = "npm-secret";
+    process.env.OPENAI_API_KEY = "sk-test";
+    try {
+      spawnDetachedPost({ url: "https://x.test", timeoutMs: 1000 });
+      const env = getChildEnv();
+      expect(env!.AWS_SECRET_ACCESS_KEY).toBeUndefined();
+      expect(env!.NPM_TOKEN).toBeUndefined();
+      expect(env!.OPENAI_API_KEY).toBeUndefined();
+    } finally {
+      delete process.env.AWS_SECRET_ACCESS_KEY;
+      delete process.env.NPM_TOKEN;
+      delete process.env.OPENAI_API_KEY;
+    }
+  });
+
+  it("propagates PATH, HOME, and NODE_EXTRA_CA_CERTS when present", () => {
+    const origPath = process.env.PATH;
+    process.env.NODE_EXTRA_CA_CERTS = "/etc/ssl/custom-ca.pem";
+    try {
+      spawnDetachedPost({ url: "https://x.test", timeoutMs: 1000 });
+      const env = getChildEnv();
+      expect(env!.PATH).toBe(origPath);
+      expect(env!.NODE_EXTRA_CA_CERTS).toBe("/etc/ssl/custom-ca.pem");
+    } finally {
+      delete process.env.NODE_EXTRA_CA_CERTS;
+    }
+  });
+
+  it("always sets CHAPA_BG_URL, CHAPA_BG_TIMEOUT_MS, CHAPA_BG_TOKEN, CHAPA_BG_BODY, CHAPA_BG_INSECURE", () => {
+    spawnDetachedPost({
+      url: "https://chapa.test/api/telemetry",
+      timeoutMs: 5000,
+      body: { hello: "world" },
+      token: "chapa-token",
+      insecure: true,
+    });
+    const env = getChildEnv();
+    expect(env!.CHAPA_BG_URL).toBe("https://chapa.test/api/telemetry");
+    expect(env!.CHAPA_BG_TIMEOUT_MS).toBe("5000");
+    expect(env!.CHAPA_BG_TOKEN).toBe("chapa-token");
+    expect(env!.CHAPA_BG_BODY).toBe(JSON.stringify({ hello: "world" }));
+    expect(env!.CHAPA_BG_INSECURE).toBe("1");
+  });
+
+  it("sets CHAPA_BG_INSECURE to empty string when insecure is false/undefined", () => {
+    spawnDetachedPost({ url: "https://x.test", timeoutMs: 1000 });
+    const env = getChildEnv();
+    expect(env!.CHAPA_BG_INSECURE).toBe("");
+  });
+
+  it("sets CHAPA_BG_BODY to empty string when body is undefined", () => {
+    spawnDetachedPost({ url: "https://x.test", timeoutMs: 1000 });
+    const env = getChildEnv();
+    expect(env!.CHAPA_BG_BODY).toBe("");
+  });
+
+  it("calls unref on the spawned child so the parent can exit", () => {
+    spawnDetachedPost({ url: "https://x.test", timeoutMs: 1000 });
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
+    const unref = getMockUnref();
+    expect(unref).toHaveBeenCalled();
+  });
+});

--- a/src/background.ts
+++ b/src/background.ts
@@ -5,6 +5,7 @@ interface DetachedPostOptions {
   timeoutMs: number;
   token?: string;
   url: string;
+  insecure?: boolean;
 }
 
 const DETACHED_POST_SCRIPT = `
@@ -12,9 +13,14 @@ const url = process.env.CHAPA_BG_URL;
 const timeoutMs = Number(process.env.CHAPA_BG_TIMEOUT_MS ?? "0");
 const token = process.env.CHAPA_BG_TOKEN || "";
 const rawBody = process.env.CHAPA_BG_BODY;
+const insecure = process.env.CHAPA_BG_INSECURE === "1";
 
 if (!url) {
   process.exit(0);
+}
+
+if (insecure) {
+  process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
 }
 
 const headers = {};
@@ -41,11 +47,34 @@ try {
 }
 `;
 
+const ALLOWED_ENV_VARS = [
+  "PATH",
+  "HOME",
+  "USERPROFILE",
+  "SystemRoot",
+  "APPDATA",
+  "TMPDIR", "TEMP", "TMP",
+  "NODE_PATH",
+  "NODE_EXTRA_CA_CERTS",
+  "SSL_CERT_FILE",
+  "SSL_CERT_DIR",
+] as const;
+
+function buildChildEnv(extras: Record<string, string>): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {};
+  for (const key of ALLOWED_ENV_VARS) {
+    const v = process.env[key];
+    if (v !== undefined) env[key] = v;
+  }
+  return { ...env, ...extras };
+}
+
 export function spawnDetachedPost({
   body,
   timeoutMs,
   token,
   url,
+  insecure,
 }: DetachedPostOptions): void {
   try {
     const child = spawn(
@@ -53,13 +82,13 @@ export function spawnDetachedPost({
       ["--input-type=module", "--eval", DETACHED_POST_SCRIPT],
       {
         detached: true,
-        env: {
-          ...process.env,
+        env: buildChildEnv({
           CHAPA_BG_BODY: body === undefined ? "" : JSON.stringify(body),
           CHAPA_BG_TIMEOUT_MS: String(timeoutMs),
           CHAPA_BG_TOKEN: token ?? "",
           CHAPA_BG_URL: url,
-        },
+          CHAPA_BG_INSECURE: insecure ? "1" : "",
+        }),
         stdio: "ignore",
       },
     );

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -38,6 +38,28 @@ describe("parseArgs", () => {
     expect(args.serverExplicit).toBe(false);
   });
 
+  it("serverExplicit is true for --server=URL form", () => {
+    const args = parseArgs(["merge", "--server=http://localhost:3001", "--emu-handle", "foo"]);
+    expect(args.serverExplicit).toBe(true);
+    expect(args.server).toBe("http://localhost:3001");
+  });
+
+  it("serverExplicit is true for space-separated --server URL form", () => {
+    const args = parseArgs(["merge", "--server", "http://localhost:3001", "--emu-handle", "foo"]);
+    expect(args.serverExplicit).toBe(true);
+    expect(args.server).toBe("http://localhost:3001");
+  });
+
+  it("serverExplicit is false when --server is absent", () => {
+    const args = parseArgs(["merge", "--emu-handle", "foo"]);
+    expect(args.serverExplicit).toBe(false);
+  });
+
+  it("serverExplicit is false when a value merely contains '--server' as substring", () => {
+    const args = parseArgs(["merge", "--emu-handle", "not--server"]);
+    expect(args.serverExplicit).toBe(false);
+  });
+
   it("returns null command when no positional arg", () => {
     const args = parseArgs(["--handle", "juan294"]);
     expect(args.command).toBeNull();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -100,7 +100,7 @@ export function parseArgs(argv: string[]): CliArgs {
     token: values.token as string | undefined,
     file: values.file as string | undefined,
     server: (values.server as string) ?? DEFAULT_SERVER,
-    serverExplicit: argv.includes("--server"),
+    serverExplicit: argv.some(a => a === "--server" || a.startsWith("--server=")),
     verbose: (values.verbose as boolean) ?? false,
     json: (values.json as boolean) ?? false,
     insecure: (values.insecure as boolean) ?? false,

--- a/src/fetch-emu.test.ts
+++ b/src/fetch-emu.test.ts
@@ -526,6 +526,56 @@ describe("fetchEmuStats", () => {
     expect(secondRequestBody.variables.prCursor).toBe("cursor-100");
   });
 
+  it("stops paginating after MAX_PR_PAGES and returns a graphql errorCategory", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    // Build a response factory that always reports hasNextPage: true
+    const makePageResponse = (cursor: string) =>
+      jsonResponse({
+        data: {
+          user: {
+            login: "runaway",
+            name: null,
+            avatarUrl: "https://example.com/avatar.png",
+            contributionsCollection: {
+              contributionCalendar: { totalContributions: 0, weeks: [] },
+              pullRequestContributions: {
+                totalCount: 0,
+                nodes: [],
+                pageInfo: {
+                  hasNextPage: true,
+                  endCursor: cursor,
+                },
+              },
+              pullRequestReviewContributions: { totalCount: 0 },
+              issueContributions: { totalCount: 0 },
+            },
+            repositories: { totalCount: 0, nodes: [] },
+            ownedRepos: { nodes: [] },
+          },
+        },
+      });
+
+    // mockFetch always returns hasNextPage: true with a rotating cursor
+    mockFetch.mockImplementation((_, opts: RequestInit) => {
+      const body = JSON.parse(opts.body as string) as { variables: { prCursor?: string | null } };
+      const cursor = body.variables.prCursor ?? "cursor-0";
+      const nextCursor = `cursor-next-${cursor}`;
+      return Promise.resolve(makePageResponse(nextCursor));
+    });
+
+    const result = await fetchEmuStats("runaway", "ghp_token");
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected failure");
+    expect(result.errorCategory).toBe("graphql");
+    expect(result.error).toMatch(/exceeded/i);
+    // 1 initial request + 50 pagination requests = 51 total
+    expect(mockFetch).toHaveBeenCalledTimes(51);
+
+    errorSpy.mockRestore();
+  });
+
   it("maps timeout failures into a stable error path", async () => {
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const timeoutError = new Error("The operation was aborted due to timeout");

--- a/src/fetch-emu.ts
+++ b/src/fetch-emu.ts
@@ -78,6 +78,11 @@ type PullRequestContributionNode = NonNullable<PullRequestContributionConnection
 /** Maximum characters to log from error response bodies or GraphQL errors. */
 const MAX_ERROR_BODY_LENGTH = 200;
 
+/** Maximum number of GraphQL pullRequestContributions pagination pages.
+ *  Each page returns up to 100 PRs, so this caps total PRs at ~5 000.
+ *  Guards against runaway pagination if upstream pageInfo misbehaves. */
+const MAX_PR_PAGES = 50;
+
 /** Truncate a string to the given max length, appending "..." if truncated. */
 function truncate(s: string, max: number): string {
   return s.length > max ? s.slice(0, max) + "..." : s;
@@ -242,7 +247,18 @@ export async function fetchEmuStats(
       endCursor: null,
     };
 
+    let pagesFetched = 0;
     while (hasNextPage) {
+      if (pagesFetched >= MAX_PR_PAGES) {
+        const msg = `[cli] GraphQL pagination exceeded maximum of ${MAX_PR_PAGES} pages for ${login}`;
+        logError(log, msg);
+        return {
+          ok: false,
+          error: `GraphQL pagination exceeded ${MAX_PR_PAGES} pages — aborting to avoid runaway requests`,
+          errorCategory: "graphql",
+        };
+      }
+
       if (!endCursor) {
         const msg = `[cli] GraphQL pagination error for ${login}: missing endCursor`;
         logError(log, msg);
@@ -289,6 +305,7 @@ export async function fetchEmuStats(
       prNodes.push(...normalizePullRequestNodes(pageConnection.nodes));
       hasNextPage = pageInfo.hasNextPage;
       endCursor = pageInfo.endCursor;
+      pagesFetched++;
     }
 
     const raw: RawContributionData = {

--- a/src/http.test.ts
+++ b/src/http.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { requestJson } from "./http.js";
+
+describe("requestJson with insecure: true", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    delete process.env.NODE_TLS_REJECT_UNAUTHORIZED;
+  });
+
+  it("sets NODE_TLS_REJECT_UNAUTHORIZED='0' for the duration of the fetch", async () => {
+    let envDuringFetch: string | undefined;
+    vi.stubGlobal("fetch", vi.fn(async () => {
+      envDuringFetch = process.env.NODE_TLS_REJECT_UNAUTHORIZED;
+      return new Response("{}", { status: 200 });
+    }));
+
+    delete process.env.NODE_TLS_REJECT_UNAUTHORIZED;
+    await requestJson({ url: "https://x.test", insecure: true });
+
+    expect(envDuringFetch).toBe("0");
+    expect(process.env.NODE_TLS_REJECT_UNAUTHORIZED).toBeUndefined();
+  });
+
+  it("restores NODE_TLS_REJECT_UNAUTHORIZED after a fetch that throws", async () => {
+    delete process.env.NODE_TLS_REJECT_UNAUTHORIZED;
+    vi.stubGlobal("fetch", vi.fn(async () => {
+      throw new Error("network boom");
+    }));
+
+    await requestJson({ url: "https://x.test", insecure: true });
+    expect(process.env.NODE_TLS_REJECT_UNAUTHORIZED).toBeUndefined();
+  });
+
+  it("preserves a previously-set NODE_TLS_REJECT_UNAUTHORIZED value", async () => {
+    process.env.NODE_TLS_REJECT_UNAUTHORIZED = "1";
+    vi.stubGlobal("fetch", vi.fn(async () => new Response("{}", { status: 200 })));
+
+    await requestJson({ url: "https://x.test", insecure: true });
+    expect(process.env.NODE_TLS_REJECT_UNAUTHORIZED).toBe("1");
+  });
+
+  it("does not touch the env when insecure is false/undefined", async () => {
+    delete process.env.NODE_TLS_REJECT_UNAUTHORIZED;
+    vi.stubGlobal("fetch", vi.fn(async () => {
+      expect(process.env.NODE_TLS_REJECT_UNAUTHORIZED).toBeUndefined();
+      return new Response("{}", { status: 200 });
+    }));
+    await requestJson({ url: "https://x.test" });
+    expect(process.env.NODE_TLS_REJECT_UNAUTHORIZED).toBeUndefined();
+  });
+});

--- a/src/http.ts
+++ b/src/http.ts
@@ -33,6 +33,21 @@ interface RequestOptions<TFallback> {
   body?: BodyInit | object;
   timeoutMs?: number;
   fallbackData?: TFallback;
+  insecure?: boolean;
+}
+
+async function withInsecureTls<T>(fn: () => Promise<T>): Promise<T> {
+  const prev = process.env.NODE_TLS_REJECT_UNAUTHORIZED;
+  process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+  try {
+    return await fn();
+  } finally {
+    if (prev === undefined) {
+      delete process.env.NODE_TLS_REJECT_UNAUTHORIZED;
+    } else {
+      process.env.NODE_TLS_REJECT_UNAUTHORIZED = prev;
+    }
+  }
 }
 
 const DEFAULT_TIMEOUT_MS = 30_000;
@@ -106,13 +121,16 @@ async function makeRequest(
 
   const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
 
-  try {
-    const response = await fetch(opts.url, {
+  const doFetch = () =>
+    fetch(opts.url, {
       method: opts.method ?? "GET",
       headers,
       body: normalizeBody(opts.body, headers),
       signal: AbortSignal.timeout(timeoutMs),
     });
+
+  try {
+    const response = opts.insecure ? await withInsecureTls(doFetch) : await doFetch();
 
     if (!response.ok) {
       const raw = await response.text().catch(() => "(unreadable)");

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -316,7 +316,7 @@ describe("index.ts command dispatch", () => {
 
   // ── --insecure ───────────────────────────────────────────────────────
 
-  it("sets NODE_TLS_REJECT_UNAUTHORIZED and warns when --insecure is used", async () => {
+  it("does not globally set NODE_TLS_REJECT_UNAUTHORIZED when --insecure is used", async () => {
     const originalVal = process.env.NODE_TLS_REJECT_UNAUTHORIZED;
     delete process.env.NODE_TLS_REJECT_UNAUTHORIZED;
 
@@ -324,11 +324,12 @@ describe("index.ts command dispatch", () => {
 
     await runMain();
 
-    expect(process.env.NODE_TLS_REJECT_UNAUTHORIZED).toBe("0");
+    expect(process.env.NODE_TLS_REJECT_UNAUTHORIZED).toBeUndefined();
 
     const allWarns = spyOutput(warnSpy);
-    expect(allWarns).toContain("TLS certificate verification disabled");
     expect(allWarns).toContain("--insecure");
+    expect(allWarns).toContain("Chapa server");
+    expect(allWarns).toContain("GitHub API calls still validate TLS");
 
     // Restore
     if (originalVal !== undefined) {
@@ -351,6 +352,56 @@ describe("index.ts command dispatch", () => {
     // Restore
     if (originalVal !== undefined) {
       process.env.NODE_TLS_REJECT_UNAUTHORIZED = originalVal;
+    }
+  });
+
+  it("forwards insecure: true to uploadSupplementalStats on merge", async () => {
+    mockParseArgs.mockReturnValue(
+      defaultArgs({
+        command: "merge",
+        emuHandle: "foo",
+        handle: "juan294",
+        token: "auth-tok",
+        insecure: true,
+      }),
+    );
+    mockLoadConfig.mockReturnValue(null);
+    mockResolveToken.mockReturnValue("emu-tok");
+    mockFetchEmuStats.mockResolvedValue(successFetchResult({ commitsTotal: 5 }));
+    mockUploadSupplementalStats.mockResolvedValue({ success: true });
+
+    await runMain();
+
+    expect(mockUploadSupplementalStats).toHaveBeenCalledWith(
+      expect.objectContaining({ insecure: true }),
+    );
+  });
+
+  it("does NOT forward insecure to fetchEmuStats (GitHub always validates TLS)", async () => {
+    mockParseArgs.mockReturnValue(
+      defaultArgs({
+        command: "merge",
+        emuHandle: "foo",
+        handle: "juan294",
+        token: "auth-tok",
+        insecure: true,
+      }),
+    );
+    mockLoadConfig.mockReturnValue(null);
+    mockResolveToken.mockReturnValue("emu-tok");
+    mockFetchEmuStats.mockResolvedValue(successFetchResult({ commitsTotal: 5 }));
+    mockUploadSupplementalStats.mockResolvedValue({ success: true });
+
+    await runMain();
+
+    expect(mockFetchEmuStats).toHaveBeenCalled();
+    const fetchEmuCalls = mockFetchEmuStats.mock.calls;
+    for (const callArgs of fetchEmuCalls) {
+      // callArgs[2] is the opts object passed to fetchEmuStats
+      const opts = callArgs[2] as Record<string, unknown> | undefined;
+      if (opts != null) {
+        expect(opts).not.toHaveProperty("insecure");
+      }
     }
   });
 
@@ -382,6 +433,7 @@ describe("index.ts command dispatch", () => {
         errorCategory: undefined,
         timing: expect.objectContaining({ authMs: expect.any(Number), totalMs: expect.any(Number) }),
       }),
+      expect.anything(),
     );
   });
 
@@ -434,6 +486,7 @@ describe("index.ts command dispatch", () => {
         errorCategory: "network",
         timing: expect.objectContaining({ authMs: expect.any(Number), totalMs: expect.any(Number) }),
       }),
+      expect.anything(),
     );
   });
 
@@ -628,6 +681,7 @@ describe("index.ts command dispatch", () => {
         stats: expect.objectContaining({ commitsTotal: 0 }),
         timing: expect.objectContaining({ uploadMs: 0 }),
       }),
+      expect.anything(),
     );
     expect(mockQueueTelemetry).toHaveBeenCalledTimes(1);
     expect(mockUploadSupplementalStats).not.toHaveBeenCalled();
@@ -699,6 +753,7 @@ describe("index.ts command dispatch", () => {
         targetHandle: "juan294",
         sourceHandle: "corp_user",
       }),
+      expect.anything(),
     );
     expect(mockQueueTelemetry).toHaveBeenCalledTimes(1);
   });
@@ -827,6 +882,7 @@ describe("index.ts command dispatch", () => {
         timing: expect.objectContaining({ fetchMs: expect.any(Number) }),
         cliVersion: expect.any(String),
       }),
+      expect.anything(),
     );
     expect(mockQueueTelemetry).toHaveBeenCalledTimes(1);
   });
@@ -1008,6 +1064,77 @@ describe("index.ts command dispatch", () => {
     expect(mockExit).not.toHaveBeenCalled();
   });
 
+  it("allows bracketed IPv6 loopback [::1] HTTP servers for merge", async () => {
+    mockParseArgs.mockReturnValue(
+      defaultArgs({
+        command: "merge",
+        emuHandle: "corp_user",
+        handle: "juan294",
+        token: "auth-tok",
+        server: "http://[::1]:3000",
+        serverExplicit: true,
+      }),
+    );
+    mockLoadConfig.mockReturnValue(null);
+    mockResolveToken.mockReturnValue("emu-tok");
+    mockFetchEmuStats.mockResolvedValue(successFetchResult({ commitsTotal: 10 }));
+    mockUploadSupplementalStats.mockResolvedValue({ success: true });
+
+    await runMain();
+
+    expect(mockUploadSupplementalStats).toHaveBeenCalledWith(
+      expect.objectContaining({ serverUrl: "http://[::1]:3000" }),
+    );
+    expect(mockExit).not.toHaveBeenCalled();
+  });
+
+  it("allows 127.0.0.1 HTTP servers for merge", async () => {
+    mockParseArgs.mockReturnValue(
+      defaultArgs({
+        command: "merge",
+        emuHandle: "corp_user",
+        handle: "juan294",
+        token: "auth-tok",
+        server: "http://127.0.0.1:3000",
+        serverExplicit: true,
+      }),
+    );
+    mockLoadConfig.mockReturnValue(null);
+    mockResolveToken.mockReturnValue("emu-tok");
+    mockFetchEmuStats.mockResolvedValue(successFetchResult({ commitsTotal: 10 }));
+    mockUploadSupplementalStats.mockResolvedValue({ success: true });
+
+    await runMain();
+
+    expect(mockUploadSupplementalStats).toHaveBeenCalledWith(
+      expect.objectContaining({ serverUrl: "http://127.0.0.1:3000" }),
+    );
+    expect(mockExit).not.toHaveBeenCalled();
+  });
+
+  it("rejects non-loopback HTTP servers (insecure.example.com) for merge", async () => {
+    mockParseArgs.mockReturnValue(
+      defaultArgs({
+        command: "merge",
+        emuHandle: "corp_user",
+        handle: "juan294",
+        token: "auth-tok",
+        server: "http://insecure.example.com",
+        serverExplicit: true,
+      }),
+    );
+    mockLoadConfig.mockReturnValue(null);
+    mockResolveToken.mockReturnValue("emu-tok");
+
+    await runMain();
+
+    expect(mockExit).toHaveBeenCalledWith(1);
+    expect(mockFetchEmuStats).not.toHaveBeenCalled();
+    const output = loggerOutput(mockLogger.error);
+    expect(output).toContain("HTTPS");
+    expect(output).toContain("localhost");
+  });
+
   it("surfaces config corruption instead of treating merge as logged out", async () => {
     mockParseArgs.mockReturnValue(
       defaultArgs({ command: "merge", emuHandle: "corp_user" }),
@@ -1156,6 +1283,7 @@ describe("index.ts command dispatch", () => {
         sourceHandle: "user",
         timing: expect.objectContaining({ parseMs: expect.any(Number), uploadMs: 0, totalMs: expect.any(Number) }),
       }),
+      expect.anything(),
     );
   });
 
@@ -1202,6 +1330,7 @@ describe("index.ts command dispatch", () => {
         sourceHandle: "user",
         timing: expect.objectContaining({ parseMs: expect.any(Number), uploadMs: expect.any(Number), totalMs: expect.any(Number) }),
       }),
+      expect.anything(),
     );
   });
 
@@ -1300,6 +1429,7 @@ describe("index.ts command dispatch", () => {
         sourceHandle: "user",
         timing: expect.objectContaining({ parseMs: expect.any(Number), uploadMs: expect.any(Number), totalMs: expect.any(Number) }),
       }),
+      expect.anything(),
     );
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -93,7 +93,11 @@ function deleteSavedConfig(): boolean {
 }
 
 function isLoopbackHost(hostname: string): boolean {
-  return hostname === "localhost" || hostname.endsWith(".localhost") || hostname === "127.0.0.1" || hostname === "::1";
+  return hostname === "localhost"
+    || hostname.endsWith(".localhost")
+    || hostname === "127.0.0.1"
+    || hostname === "::1"
+    || hostname === "[::1]";
 }
 
 function assertTrustedServer(serverUrl: string): void {
@@ -172,7 +176,7 @@ async function handleLogin(args: CliArgs): Promise<void> {
       stats: EMPTY_TELEMETRY_STATS,
       timing: { totalMs, authMs: totalMs },
       cliVersion: VERSION,
-    });
+    }, { insecure: args.insecure });
   }
 }
 
@@ -272,12 +276,13 @@ async function handleInsights(
       token: authToken,
       serverUrl,
       logger: log,
+      insecure: args.insecure,
     });
     uploadMs = log.timeEnd("upload");
 
   // Trigger recalculate (non-blocking, fire-and-forget)
   if (result.success) {
-    insightsModule.queueRecalculate(serverUrl, authToken);
+    insightsModule.queueRecalculate(serverUrl, authToken, { insecure: args.insecure });
   }
 
     totalMs = log.timeEnd("total");
@@ -347,7 +352,7 @@ async function handleInsights(
         uploadMs: round(uploadMs),
       },
       cliVersion: VERSION,
-    });
+    }, { insecure: args.insecure });
   }
 
   if (caught) {
@@ -440,6 +445,7 @@ async function handleMerge(args: CliArgs): Promise<void> {
       token: authToken,
       serverUrl,
       logger: log,
+      insecure: args.insecure,
     });
     uploadMs = log.timeEnd("upload");
 
@@ -516,7 +522,7 @@ async function handleMerge(args: CliArgs): Promise<void> {
           totalMs: round(totalMs || log.timeEnd("total")),
         },
         cliVersion: VERSION,
-      });
+      }, { insecure: args.insecure });
     }
   }
 
@@ -541,8 +547,8 @@ function mergeTelemetryStats(stats: {
   };
 }
 
-function emitTelemetry(serverUrl: string, payload: TelemetryPayload): void {
-  queueTelemetry(serverUrl, payload);
+function emitTelemetry(serverUrl: string, payload: TelemetryPayload, opts?: { insecure?: boolean }): void {
+  queueTelemetry(serverUrl, payload, opts);
 }
 
 // ── Main Dispatcher ───────────────────────────────────────────────────────
@@ -567,10 +573,9 @@ async function main(): Promise<void> {
     throw new CliError(`Unknown command '${args.unknownCommand}'`);
   }
 
-  // Global TLS bypass for corporate networks — applies to all commands
   if (args.insecure) {
-    process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
-    console.warn("\n⚠ TLS certificate verification disabled (--insecure).");
+    console.warn("\n⚠ TLS certificate verification disabled for the Chapa server (--insecure).");
+    console.warn("  GitHub API calls still validate TLS.");
     console.warn("  Use only on corporate networks with TLS interception.\n");
   }
 

--- a/src/insights.test.ts
+++ b/src/insights.test.ts
@@ -180,6 +180,110 @@ describe("parseInsightsHtml", () => {
     });
   });
 
+  it("parses multi-clauding with font-weight:700 (no space)", () => {
+    const html = `<html><body>
+      <p class="subtitle">10 messages across 2 sessions (2 total) | 2026-01-01 to 2026-01-02</p>
+      <div class="chart-card">
+        <div class="chart-title">Multi-Clauding (Parallel Sessions)</div>
+        <div style="display:flex;">
+          <div>
+            <div style="font-weight:700;">10</div>
+            <div style="text-transform:uppercase;">Overlap Events</div>
+          </div>
+          <div>
+            <div style="font-weight:700;">20</div>
+            <div style="text-transform:uppercase;">Sessions Involved</div>
+          </div>
+          <div>
+            <div style="font-weight:700;">30%</div>
+            <div style="text-transform:uppercase;">Of Messages</div>
+          </div>
+        </div>
+      </div>
+    </body></html>`;
+    const result = parseInsightsHtml(html);
+    expect(result.multiClauding).toEqual({
+      overlapEvents: 10,
+      sessionsInvolved: 20,
+      messagePercent: 30,
+    });
+  });
+
+  it("parses multi-clauding with font-weight: bold", () => {
+    const html = `<html><body>
+      <p class="subtitle">10 messages across 2 sessions (2 total) | 2026-01-01 to 2026-01-02</p>
+      <div class="chart-card">
+        <div class="chart-title">Multi-Clauding (Parallel Sessions)</div>
+        <div style="display:flex;">
+          <div>
+            <div style="font-weight: bold;">10</div>
+            <div style="text-transform: uppercase;">Overlap Events</div>
+          </div>
+        </div>
+      </div>
+    </body></html>`;
+    const result = parseInsightsHtml(html);
+    expect(result.multiClauding.overlapEvents).toBe(10);
+  });
+
+  it("parses multi-clauding with extra whitespace in style values", () => {
+    const html = `<html><body>
+      <p class="subtitle">10 messages across 2 sessions (2 total) | 2026-01-01 to 2026-01-02</p>
+      <div class="chart-card">
+        <div class="chart-title">Multi-Clauding (Parallel Sessions)</div>
+        <div style="display:flex;">
+          <div>
+            <div style="font-weight :  700">10</div>
+            <div style="text-transform :  uppercase">Overlap Events</div>
+          </div>
+        </div>
+      </div>
+    </body></html>`;
+    const result = parseInsightsHtml(html);
+    expect(result.multiClauding.overlapEvents).toBeGreaterThan(0);
+  });
+
+  it("returns all zeros when label/value count mismatches", () => {
+    const html = `<html><body>
+      <p class="subtitle">10 messages across 2 sessions (2 total) | 2026-01-01 to 2026-01-02</p>
+      <div class="chart-card">
+        <div class="chart-title">Multi-Clauding (Parallel Sessions)</div>
+        <div style="display:flex;">
+          <div>
+            <div style="font-weight: 700;">10</div>
+            <div style="text-transform: uppercase;">Overlap Events</div>
+          </div>
+          <div>
+            <div style="font-weight: 700;">20</div>
+          </div>
+        </div>
+      </div>
+    </body></html>`;
+    const result = parseInsightsHtml(html);
+    expect(result.multiClauding).toEqual({
+      overlapEvents: 0,
+      sessionsInvolved: 0,
+      messagePercent: 0,
+    });
+  });
+
+  it("rejects font-weight: 7000 (word boundary check)", () => {
+    const html = `<html><body>
+      <p class="subtitle">10 messages across 2 sessions (2 total) | 2026-01-01 to 2026-01-02</p>
+      <div class="chart-card">
+        <div class="chart-title">Multi-Clauding (Parallel Sessions)</div>
+        <div style="display:flex;">
+          <div>
+            <div style="font-weight: 7000">10</div>
+            <div style="text-transform: uppercase;">Overlap Events</div>
+          </div>
+        </div>
+      </div>
+    </body></html>`;
+    const result = parseInsightsHtml(html);
+    expect(result.multiClauding.overlapEvents).toBe(0);
+  });
+
   it("extracts response time", () => {
     const result = parseInsightsHtml(FIXTURE_HTML);
     expect(result.responseTime).toEqual({

--- a/src/insights.ts
+++ b/src/insights.ts
@@ -170,6 +170,9 @@ function extractVolumeStats(doc: Document): {
   return result;
 }
 
+const VALUE_STYLE = /font-weight\s*:\s*(700|bold)\b/i;
+const LABEL_STYLE = /text-transform\s*:\s*uppercase\b/i;
+
 function parseMultiClauding(card: Element | null): {
   overlapEvents: number;
   sessionsInvolved: number;
@@ -184,15 +187,19 @@ function parseMultiClauding(card: Element | null): {
 
   for (const div of statDivs) {
     const style = div.getAttribute("style") ?? "";
-    if (style.includes("font-weight: 700") || style.includes("font-weight:700")) {
+    if (VALUE_STYLE.test(style)) {
       values.push(parseNumeric(div.textContent?.trim() ?? "0"));
     }
-    if (style.includes("text-transform: uppercase") || style.includes("text-transform:uppercase")) {
+    if (LABEL_STYLE.test(style)) {
       labels.push(div.textContent?.trim().toLowerCase() ?? "");
     }
   }
 
-  for (let i = 0; i < labels.length && i < values.length; i++) {
+  if (labels.length !== values.length) {
+    return result;
+  }
+
+  for (let i = 0; i < labels.length; i++) {
     const label = labels[i]!;
     const value = values[i]!;
     if (label.includes("overlap")) result.overlapEvents = value;
@@ -306,6 +313,7 @@ interface InsightsUploadOptions {
   token: string;
   serverUrl: string;
   logger?: Logger;
+  insecure?: boolean;
 }
 
 interface InsightsUploadResult {
@@ -340,6 +348,7 @@ export async function uploadInsights(
         "Content-Type": "application/json",
       },
       body: payload,
+      insecure: opts.insecure,
     });
 
     if (!res.ok) {
@@ -403,13 +412,14 @@ export async function triggerRecalculate(
   }
 }
 
-export function queueRecalculate(serverUrl: string, token: string): void {
+export function queueRecalculate(serverUrl: string, token: string, opts?: { insecure?: boolean }): void {
   const baseUrl = stripTrailingSlashes(serverUrl);
 
   spawnDetachedPost({
     url: `${baseUrl}/api/recalculate`,
     timeoutMs: 30_000,
     token,
+    insecure: opts?.insecure,
   });
 }
 

--- a/src/login.test.ts
+++ b/src/login.test.ts
@@ -255,8 +255,8 @@ describe("login", () => {
     expect(mockSaveConfig).toHaveBeenCalledOnce();
   });
 
-  it("does not set or restore NODE_TLS_REJECT_UNAUTHORIZED (handled by index.ts)", async () => {
-    // TLS bypass is now global in index.ts, not in login().
+  it("never mutates NODE_TLS_REJECT_UNAUTHORIZED — scoping is per-request in http.ts", async () => {
+    // TLS bypass is per-request in http.ts (withInsecureTls), not in login().
     // Verify login() does NOT touch the env var.
     const originalVal = process.env.NODE_TLS_REJECT_UNAUTHORIZED;
     delete process.env.NODE_TLS_REJECT_UNAUTHORIZED;

--- a/src/login.ts
+++ b/src/login.ts
@@ -159,6 +159,7 @@ export async function login(serverUrl: string, opts: LoginOptions = {}): Promise
       const res = await requestJson<PollResponse>({
         url: `${baseUrl}/api/cli/auth/poll?session=${sessionId}`,
         timeoutMs: 10_000,
+        insecure,
       });
       if (!res.ok) {
         serverErrorLogged = handlePollFailure(res, i + 1, verbose, insecure, serverErrorLogged);

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -54,6 +54,7 @@ export function classifyError(message: string): TelemetryErrorCategory {
 export async function sendTelemetry(
   serverUrl: string,
   payload: TelemetryPayload,
+  opts?: { insecure?: boolean },
 ): Promise<void> {
   const baseUrl = stripTrailingSlashes(serverUrl);
   const url = `${baseUrl}/api/telemetry`;
@@ -65,18 +66,20 @@ export async function sendTelemetry(
       timeoutMs: 5000,
       body: payload,
       fallbackData: {},
+      insecure: opts?.insecure,
     });
   } catch {
     // Intentionally swallowed — telemetry must never block or fail the CLI
   }
 }
 
-export function queueTelemetry(serverUrl: string, payload: TelemetryPayload): void {
+export function queueTelemetry(serverUrl: string, payload: TelemetryPayload, opts?: { insecure?: boolean }): void {
   const baseUrl = stripTrailingSlashes(serverUrl);
 
   spawnDetachedPost({
     url: `${baseUrl}/api/telemetry`,
     timeoutMs: 5000,
     body: payload,
+    insecure: opts?.insecure,
   });
 }

--- a/src/upload.ts
+++ b/src/upload.ts
@@ -10,6 +10,7 @@ interface UploadOptions {
   token: string;
   serverUrl: string;
   logger?: Logger;
+  insecure?: boolean;
 }
 
 interface UploadResult {
@@ -42,6 +43,7 @@ export async function uploadSupplementalStats(
         "Content-Type": "application/json",
       },
       body: payload,
+      insecure: opts.insecure,
     });
 
     if (!res.ok) {


### PR DESCRIPTION
## Summary

Implements all 6 items from the senior developer validation report (issue #87).

- **Phase 1** (`src/cli.ts`): `--server=URL` form now sets `serverExplicit: true`. Previously only the space-separated form was detected, causing the saved config server to silently win.
- **Phase 2** (`src/index.ts`): `http://[::1]:<port>` now accepted as trusted loopback. On Node 20+, `new URL(...).hostname` returns `"[::1]"` (bracketed), which the old check against bare `"::1"` rejected.
- **Phase 3** (`src/http.ts` + callers): `--insecure` now scopes TLS bypass to Chapa-bound requests only via `withInsecureTls`. GitHub API calls always validate TLS. `NODE_TLS_REJECT_UNAUTHORIZED` is unset after each request.
- **Phase 4** (`src/background.ts`): Replace `...process.env` spread in `spawnDetachedPost` with a narrow allow-list — stops `GITHUB_EMU_TOKEN` and other secrets from leaking to the detached child process.
- **Phase 5** (`src/fetch-emu.ts`): Add `MAX_PR_PAGES = 50` hard cap to GraphQL pagination loop. Fails fast with `errorCategory: "graphql"` instead of hanging forever.
- **Phase 6** (`src/insights.ts`): Replace brittle substring checks in `parseMultiClauding` with whitespace-tolerant regexes; return zeros (not wrong-paired values) on label/value count mismatch.

## New files

- `src/http.test.ts` — `withInsecureTls` unit tests
- `src/background.test.ts` — `spawnDetachedPost` env isolation tests

## Explicitly deferred (per senior dev)

GraphQL query split, telemetry-helper extraction, `readFileSync` → async, `shared.ts` split, retry/backoff, error-body decoding centralization, dead-export removal.

## Test plan

- [x] `pnpm run typecheck` passes
- [x] `pnpm test` — 317 passing, 1 pre-existing timeout on `--version` (also fails on `develop`, unrelated to this PR)
- [x] `pnpm run build` — dist/index.js has shebang, zero runtime deps

🤖 Generated with [Claude Code](https://claude.com/claude-code)