### PR TITLE
fix(infra): gate publish.yml on main branch provenance

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,6 +34,14 @@ jobs:
             exit 1
           fi
 
+          PKG_VERSION="$(node -p "require('./package.json').version")"
+          RELEASE_TAG="${{ github.event.release.tag_name }}"
+          EXPECTED_TAG="v${PKG_VERSION}"
+          if [ "$RELEASE_TAG" != "$EXPECTED_TAG" ]; then
+            echo "::error::Release tag '${RELEASE_TAG}' does not match package.json version '${PKG_VERSION}' (expected tag '${EXPECTED_TAG}')."
+            exit 1
+          fi
+
       - uses: pnpm/action-setup@v4
 
       - uses: actions/setup-node@v6


### PR DESCRIPTION
Closes #93

Adds package.json version alignment check to the existing branch provenance step in `publish.yml`. The workflow now hard-fails if:
1. Release `target_commitish` is not `main`
2. Tagged commit is not reachable from `origin/main`
3. Release tag name does not match `v{package.json version}`

**Files changed:** `.github/workflows/publish.yml`