### PR TITLE
chore(release): 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-08-10
+
+### Security
+
+- Remove a shell injection risk in the Windows browser launch during
+  login (#103, #104)
+- Enforce HTTPS in the login device flow and reject non-loopback
+  redirect hosts (#91, #95, #96, #97, #98)
+- Enforce HTTPS and strict 2xx parsing in the shared request
+  transport (#94, #95, #99)
+
+### Fixed
+
+- Paginate EMU pull request contributions beyond the 100-node GraphQL
+  cap, which silently truncated stats for high-volume accounts (#92)
+- Emit telemetry failure events on insights and login early-exit
+  paths, and add command context to payloads (#101)
+- Correct server-selection intent, config corruption handling, and
+  command UX in the CLI (#91, #95, #96, #97, #98)
+
+### Performance
+
+- Cache DOM lookups in insights parsing to avoid redundant
+  rescans (#102)
+
 ### Changed
 
 - Publish to npm via OIDC trusted publishing with SLSA provenance
-  instead of a stored `NPM_TOKEN` secret
+  instead of a stored `NPM_TOKEN` secret (#123)
 
 ### Removed
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chapa-cli",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "Merge GitHub EMU contributions into your Chapa developer impact badge",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Version bump and CHANGELOG for 0.5.0 — the first release since 0.4.1 (2026-04-18) and the first to publish via OIDC trusted publishing.

## Why minor, not patch

The backlog since 0.4.1 carries three security fixes and one silent-truncation correctness bug:

- Shell injection risk removed from the Windows browser launch during login (#103, #104)
- HTTPS enforced in the login device flow, non-loopback redirect hosts rejected (#91, #95–#98)
- HTTPS + strict 2xx parsing enforced in the shared request transport (#94, #95, #99)
- EMU pull request contributions paginated beyond the 100-node GraphQL cap, which silently truncated stats for high-volume accounts (#92)

## CHANGELOG backfill

`Unreleased` documented only the publishing change, so the 0.5.0 section is reconstructed from the 68-commit backlog and grouped Security / Fixed / Performance / Changed / Removed.

## Verification

438 tests, typecheck, build — all green. Tarball packed and inspected: `dist/` complete, `#!/usr/bin/env node` shebang present, 144K.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ly2o9BqerswDtHDo3qYRmC